### PR TITLE
Patch embedding pipeline

### DIFF
--- a/configs/patch_embedding_pipeline_example.yaml
+++ b/configs/patch_embedding_pipeline_example.yaml
@@ -1,0 +1,43 @@
+data:
+  videos_dir: /teamspace/studios/this_studio/lightning-action/data/videos  # MP4 directory
+  labels_dir: /teamspace/studios/this_studio/lightning-action/data/labels_numpy  # Numpy directory
+  expt_ids:
+  - 1.1.28R
+  - 1.1.28L
+  - 1.2.2R
+  - 1.2.28R
+  - 1.3.1R
+  - 1.4.1R
+  - 2.1.28L
+  - 3.1.28L
+  - 3.2.28L
+  ignore_index: -100
+  seed: 1
+model:
+  backbone: dtcn
+  activation: lrelu
+  dropout_rate: 0.1
+  input_size: 1536
+  num_hid_units: 64
+  num_lags: 2
+  num_layers: 4
+  output_size: 3
+  seed: 1
+  beast_checkpoint: /teamspace/studios/this_studio/lightning-action/data/checkpoints/beast/vitm.ckpt
+  freeze_beast: true
+optimizer:
+  T_max: 400
+  lr: 0.000347687001741302
+  scheduler: null
+  type: Adam
+  wd: 0.0001
+training:
+  batch_size: 1  
+  device: gpu
+  early_stopping: true
+  early_stopping_patience: 40
+  num_epochs: 400
+  num_workers: 0
+  sequence_length: 128
+  train_probability: 0.95
+  val_probability: 0.05

--- a/lightning_action/api/video_model.py
+++ b/lightning_action/api/video_model.py
@@ -1,0 +1,321 @@
+"""High-level API for lightning-action video models.
+
+This module provides a high-level interface for training, loading, and using
+lightning-action video models for action segmentation.
+"""
+
+import contextlib
+import os
+from pathlib import Path
+from typing import Any
+
+import lightning as pl
+import numpy as np
+import pandas as pd
+import torch
+import yaml
+from typeguard import typechecked
+
+from lightning_action.data.video_datamodule import VideoDataModule
+from lightning_action.models.video_segmenter import VideoSegmenter
+from lightning_action.video_train import train_video
+import logging
+
+
+@contextlib.contextmanager
+def chdir(path: Path):
+    """Context manager for changing directories.
+    
+    Args:
+        path: directory to change to
+    """
+    old_cwd = os.getcwd()
+    try:
+        os.chdir(path)
+        yield
+    finally:
+        os.chdir(old_cwd)
+
+
+@typechecked
+class VideoModel:
+    """High-level API wrapper for lightning-action video models.
+
+    This class manages both the Lightning model and the training/inference processes,
+    providing a convenient interface for video action segmentation tasks.
+    """
+
+    def __init__(
+        self,
+        model: VideoSegmenter,
+        config: dict[str, Any],
+        model_dir: str | Path | None = None,
+    ) -> None:
+        """Initialize with Lightning model and config.
+        
+        Args:
+            model: Lightning segmentation model
+            config: configuration dictionary
+            model_dir: directory containing model files (optional)
+        """
+        self.model = model
+        self.config = config
+        self.model_dir = Path(model_dir) if model_dir is not None else None
+
+    @classmethod
+    def from_dir(cls, model_dir: str | Path):
+        """Load a Lightning model from a directory.
+
+        Args:
+            model_dir: path to directory containing model checkpoint and config
+
+        Returns:
+            initialized model wrapper
+        
+        Raises:
+            FileNotFoundError: if config or checkpoint files are not found
+        """
+        model_dir = Path(model_dir)
+        
+        # load config
+        config_path = model_dir / 'config.yaml'
+        if not config_path.exists():
+            # fallback to hparams.yaml for compatibility
+            config_path = model_dir / 'hparams.yaml'
+        
+        if not config_path.exists():
+            raise FileNotFoundError(f'Config file not found in {model_dir}')
+            
+        with open(config_path) as f:
+            config = yaml.safe_load(f)
+
+        # create model
+        model = VideoSegmenter(config)
+
+        # load Lightning checkpoint
+        checkpoint_patterns = ['*best*.ckpt', '*.ckpt', '*best*.pt', '*.pt']
+        checkpoint_path = None
+        
+        for pattern in checkpoint_patterns:
+            checkpoints = list(model_dir.rglob(pattern))
+            if checkpoints:
+                checkpoint_path = checkpoints[0]
+                break
+                
+        if checkpoint_path is None:
+            raise FileNotFoundError(f'No checkpoint files found in {model_dir}')
+            
+        # load checkpoint
+        if checkpoint_path.suffix == '.ckpt':
+            # Lightning checkpoint
+            model = VideoSegmenter.load_from_checkpoint(checkpoint_path, config=config)
+        else:
+            # PyTorch state dict
+            state_dict = torch.load(checkpoint_path, map_location='cpu')
+            model.load_state_dict(state_dict)
+            
+        model.eval()
+        print(f'Loaded model weights from {checkpoint_path}')
+
+        return cls(model, config, model_dir)
+
+    @classmethod
+    def from_config(cls, config_path: str | Path | dict):
+        """Create a new Lightning model from a config file.
+
+        Args:
+            config_path: path to config file or config dictionary
+
+        Returns:
+            initialized model wrapper with untrained model
+        """
+        if not isinstance(config_path, dict):
+            config_path = Path(config_path)
+            if not config_path.exists():
+                raise FileNotFoundError(f'Config file not found: {config_path}')
+            with open(config_path) as f:
+                config = yaml.safe_load(f)
+        else:
+            config = config_path
+
+        model = VideoSegmenter(config)
+
+        return cls(model, config, model_dir=None)
+
+    def train(self, output_dir: str | Path = 'runs/default', post_inference: bool = True):
+        """Train the model using PyTorch Lightning.
+
+        After training is complete, automatically runs inference on all experiment IDs
+        used for training and saves predictions to output_dir/predictions/.
+
+        Args:
+            output_dir: directory to save checkpoints and logs
+            post_inference: run inference on all training expts and store in model_dir/predictions
+        """
+        self.model_dir = Path(output_dir)
+        self.model_dir.mkdir(exist_ok=True, parents=True)
+        with chdir(self.model_dir):
+            self.model = train_video(self.config, self.model, output_dir=self.model_dir)
+
+        # automatically run inference on training experiments
+        if post_inference:
+            self._run_post_training_inference()
+    
+    def _run_post_training_inference(self):
+        """Run inference on all training experiment IDs after training completes.
+        
+        This method extracts the experiment IDs from the training configuration,
+        determines the appropriate data path and input directory, and runs inference
+        on all experiments used for training.
+        """
+        if self.model is None:
+            print('Warning: No trained model found, skipping post-training inference')
+            return
+            
+        if self.model_dir is None:
+            print('Warning: No model directory found, skipping post-training inference')
+            return
+            
+        # extract data configuration to get experiment IDs
+        videos_dir = self.config['data']['videos_dir']
+        labels_dir = self.config['data']['labels_dir']
+        expt_ids = self.config['data']['expt_ids']
+        
+        # create predictions directory
+        predictions_dir = self.model_dir / 'predictions'
+        predictions_dir.mkdir(exist_ok=True)
+        
+        print(f'Running post-training inference on all training experiments...')
+        print(f'Videos directory: {videos_dir}')
+        print(f'Labels directory: {labels_dir}')
+        print(f'Experiment IDs: {expt_ids if expt_ids else "all"}')
+        print(f'Predictions will be saved to: {predictions_dir}')
+        
+        try:
+            # run inference using the existing predict method
+            self.predict(
+                videos_dir=videos_dir,
+                labels_dir=labels_dir,
+                output_dir=predictions_dir,
+                expt_ids=expt_ids,
+            )
+            print('Post-training inference completed successfully!')
+        except Exception as e:
+            print(f'Warning: Post-training inference failed with error: {e}')
+            print('Training completed successfully, but automatic inference was skipped.')
+    
+    def predict(
+        self,
+        videos_dir: str | Path,
+        labels_dir: str | Path,
+        output_dir: str | Path,
+        output_file: str | Path | None = None,
+        expt_ids: list[str] | None = None,
+    ):
+        """Generate predictions for data using the trained model.
+
+        Creates separate prediction files for each experiment in the output directory.
+
+        Args:
+            videos_dir: directory containing MP4 video files
+            labels_dir: directory containing NumPy (.npy) label files
+            output_dir: directory to save prediction files (one per experiment)
+            output_file: full path to save prediction file; overwrites output_dir if not None
+            expt_ids: list of experiment IDs to predict on (None for all)
+            
+        Raises:
+            ValueError: if model is not trained
+        """
+        videos_dir = Path(videos_dir)
+        labels_dir = Path(labels_dir)
+
+        if self.model is None:
+            raise ValueError('Model must be trained or loaded before prediction')
+
+        if output_file is not None and (expt_ids is not None and len(expt_ids) > 1):
+            raise RuntimeError('Can only supply `output_file` when specifying a single expt_id')
+
+        # get all expt_ids if not provided
+        if expt_ids is None:
+            expt_ids = [f[:-4] for f in os.listdir(videos_dir) if f.endswith('.mp4')]
+
+        # get training config
+        training_config = self.config.get('training', {})
+
+        # loop over each experiment and create separate predictions
+        for expt_id in expt_ids:
+            print(f'Generating predictions for experiment: {expt_id}')
+
+            # create data config for single experiment
+            data_config = self.config['data'].copy()
+            data_config['expt_ids'] = [expt_id]
+            data_config['videos_dir'] = str(videos_dir)
+            data_config['labels_dir'] = str(labels_dir)
+
+            # create datamodule for this experiment
+            datamodule = VideoDataModule(
+                data_config=data_config,
+                sequence_length=training_config.get('sequence_length', 128),
+                batch_size=1,
+                num_workers=training_config.get('num_workers', 0),
+                train_probability=1.0,
+                val_probability=0.0,
+                seed=training_config.get('seed', 42),
+            )
+            
+            # setup for prediction
+            datamodule.setup('predict')
+            
+            # get total_frames for this video
+            label_path = labels_dir / f'{expt_id}.npy'
+            if not label_path.exists():
+                raise FileNotFoundError(f'Missing label file: {label_path}')
+            labels_array = np.load(str(label_path), mmap_mode='r')
+            total_frames = labels_array.shape[0]
+            
+            # create trainer for prediction
+            device = training_config.get('device', 'cpu')
+            trainer_config = {
+                'accelerator': 'gpu' if device == 'gpu' and torch.cuda.is_available() else 'cpu',
+                'devices': 1,
+                'logger': False,
+                'enable_checkpointing': False,
+                'enable_progress_bar': False,
+            }
+            
+            trainer = pl.Trainer(**trainer_config)
+            
+            # generate predictions for this experiment
+            predictions = trainer.predict(self.model, datamodule=datamodule)
+            
+            # concatenate predictions from all batches
+            all_probs = []
+            num_lags = self.config['model']['num_lags']
+            for batch_preds in predictions:
+                probs_full = batch_preds['probabilities'][0].cpu().numpy() 
+                all_probs.append(probs_full)
+            
+            # stack predictions from all chunks
+            final_probs = np.vstack(all_probs)
+            
+            # get original data length for this experiment and pad with NaNs if needed
+            current_length = final_probs.shape[0]
+            if current_length < total_frames:
+                # pad with NaNs to match original input file length
+                num_classes = final_probs.shape[1]
+                padding_rows = total_frames - current_length
+                nan_padding = np.full((padding_rows, num_classes), np.nan)
+                final_probs = np.vstack([final_probs, nan_padding])
+                print(f'Padded predictions from {current_length} to {total_frames} rows')
+            
+            # create dataframe and save predictions for this experiment
+            df = pd.DataFrame(data=final_probs, columns=datamodule.get_label_names())
+            if output_file is not None:
+                output_file_ = Path(output_file)
+            else:
+                output_file_ = output_dir / f'{expt_id}_predictions.csv'
+            output_file_.parent.mkdir(exist_ok=True, parents=True)
+            df.to_csv(output_file_)
+            print(f'Saved predictions to {output_file_}')
+
+        print(f'Completed predictions for {len(expt_ids)} experiments in {output_dir}')

--- a/lightning_action/data/video_datamodule.py
+++ b/lightning_action/data/video_datamodule.py
@@ -1,0 +1,210 @@
+"""Lightning DataModule for video action segmentation datasets.
+
+This module provides a PyTorch Lightning DataModule that wraps the VideoDataset
+for easy integration with Lightning training workflows.
+"""
+import logging
+from typing import Any
+
+import lightning as pl
+import numpy as np
+import torch
+from torch.utils.data import DataLoader, random_split
+from typeguard import typechecked
+
+from lightning_action.data.video_dataset import VideoDataset
+from lightning_action.data.utils import split_sizes_from_probabilities
+
+logger = logging.getLogger(__name__)
+
+class VideoDataModule(pl.LightningDataModule):
+    """Lightning DataModule for video action segmentation tasks.
+    
+    This DataModule handles loading, splitting, and serving video data
+    for training action segmentation models. It wraps the VideoDataset
+    and provides train/validation DataLoaders.
+    """
+
+    @typechecked
+    def __init__(
+        self,
+        data_config: dict[str, Any],
+        sequence_length: int = 128,
+        batch_size: int = 1,
+        num_workers: int = 0,
+        train_probability: float = 0.95,
+        val_probability: float | None = None,
+        pin_memory: bool = True,
+        persistent_workers: bool = False,
+        seed: int = 42,
+    ):
+        """Initialize VideoDataModule.
+        
+        Args:
+            data_config: configuration dictionary with keys:
+                - 'videos_dir': directory with MP4 videos
+                - 'labels_dir': directory with NumPy labels
+                - 'expt_ids': list of dataset identifiers
+                - 'resolution': output frame resolution (optional)
+                - 'num_lags': number of context frames on each side
+                - 'overlap': overlap between chunks
+            sequence_length: length of each video chunk for predictions
+            batch_size: batch size for DataLoaders
+            num_workers: number of worker processes for data loading
+            train_probability: fraction of data used for training
+            val_probability: fraction of data used for validation (defaults to 1-train_probability)
+            pin_memory: whether to use pinned memory for faster GPU transfer
+            persistent_workers: whether to keep workers alive between epochs
+            seed: random seed for splitting
+            
+        Raises:
+            ValueError: if data_config is missing required keys
+        """
+        super().__init__()
+        
+        # validate data config
+        required_keys = ['videos_dir', 'labels_dir', 'expt_ids']
+        if not all(key in data_config for key in required_keys):
+            raise ValueError(f'data_config must contain keys: {required_keys}')
+        
+        # store configuration
+        self.data_config = data_config
+        self.sequence_length = sequence_length
+        self.batch_size = batch_size
+        self.num_workers = num_workers
+        self.train_probability = train_probability
+        self.val_probability = val_probability or (1 - train_probability)
+        self.pin_memory = pin_memory
+        self.persistent_workers = persistent_workers
+        self.seed = seed
+
+        # create full dataset
+        logger.info('Creating VideoDataset')
+        self.dataset = VideoDataset(
+            videos_dir=self.data_config['videos_dir'],
+            labels_dir=self.data_config['labels_dir'],
+            chunk_size=self.sequence_length,
+            overlap=self.data_config.get('overlap', 0),
+            resolution=self.data_config.get('resolution', 224),
+            expt_ids=self.data_config['expt_ids'],
+            input_size=self.data_config.get('input_size', 1536),
+            num_lags=self.data_config.get('num_lags', 0),
+            ignore_index=self.data_config.get('ignore_index', -100),
+        )
+
+        logger.info(f'Created dataset with {len(self.dataset)} chunks')
+
+        # split datasets
+        self.dataset_train = None
+        self.dataset_val = None
+
+    def setup(self, stage: str | None = None):
+        """Set up datasets for training and validation.
+        
+        Args:
+            stage: training stage ('fit', 'validate', 'test', or None)
+        """
+        if stage in [None, 'fit', 'validate']:
+            if self.dataset_train is None or self.dataset_val is None:
+                total_size = len(self.dataset)
+                train_size, val_size = split_sizes_from_probabilities(
+                    total_size,
+                    self.train_probability,
+                    self.val_probability,
+                )
+                
+                logger.info(f'Splitting dataset: {train_size} train, {val_size} val chunks')
+                np.random.seed(self.seed)
+                self.dataset_train, self.dataset_val = random_split(
+                    self.dataset,
+                    [train_size, val_size],
+                )
+
+    def train_dataloader(self) -> DataLoader:
+        """Create training DataLoader.
+        
+        Returns:
+            DataLoader for training data
+        """
+        return DataLoader(
+            self.dataset_train,
+            batch_size=self.batch_size,
+            shuffle=True,
+            num_workers=self.num_workers,
+            pin_memory=self.pin_memory,
+            persistent_workers=self.persistent_workers,
+            collate_fn=self._collate_fn,
+        )
+
+    def val_dataloader(self) -> DataLoader:
+        """Create validation DataLoader.
+        
+        Returns:
+            DataLoader for validation data
+        """
+        return DataLoader(
+            self.dataset_val,
+            batch_size=self.batch_size,
+            shuffle=False,
+            num_workers=self.num_workers,
+            pin_memory=self.pin_memory,
+            persistent_workers=self.persistent_workers,
+            collate_fn=self._collate_fn,
+        )
+
+    def predict_dataloader(self) -> DataLoader:
+        """Create prediction DataLoader.
+        
+        Returns:
+            DataLoader for prediction
+        """
+        return DataLoader(
+            self.dataset,
+            batch_size=self.batch_size,
+            shuffle=False,
+            num_workers=self.num_workers,
+            pin_memory=self.pin_memory,
+            persistent_workers=self.persistent_workers,
+            collate_fn=self._collate_fn,
+        )
+
+    @typechecked
+    def _collate_fn(self, batch: list[tuple[torch.Tensor, torch.Tensor]]) -> tuple[torch.Tensor, torch.Tensor]:
+        """Custom collate function to stack batches.
+        
+        Args:
+            batch: list of (frames, labels) tuples from VideoDataset
+            
+        Returns:
+            tuple of stacked frames and labels
+        """
+        frames, labels = zip(*batch)
+        frames = torch.stack(frames)
+        labels = torch.stack(labels)
+        return frames, labels
+
+    def get_label_names(self) -> list[str]:
+        """Get label names from the dataset.
+        
+        Returns:
+            list of label names
+        """
+        return self.dataset.get_label_names()
+
+    @property
+    def input_size(self) -> int:
+        """Get input size from the dataset.
+        
+        Returns:
+            dimensionality of input features
+        """
+        return self.dataset.input_size
+
+    @property
+    def num_classes(self) -> int:
+        """Get number of classes from the dataset.
+        
+        Returns:
+            number of label classes
+        """
+        return self.dataset.num_classes

--- a/lightning_action/data/video_datamodule.py
+++ b/lightning_action/data/video_datamodule.py
@@ -47,7 +47,6 @@ class VideoDataModule(pl.LightningDataModule):
                 - 'expt_ids': list of dataset identifiers
                 - 'resolution': output frame resolution (optional)
                 - 'num_lags': number of context frames on each side
-                - 'overlap': overlap between chunks
             sequence_length: length of each video chunk for predictions
             batch_size: batch size for DataLoaders
             num_workers: number of worker processes for data loading
@@ -84,7 +83,6 @@ class VideoDataModule(pl.LightningDataModule):
             videos_dir=self.data_config['videos_dir'],
             labels_dir=self.data_config['labels_dir'],
             chunk_size=self.sequence_length,
-            overlap=self.data_config.get('overlap', 0),
             resolution=self.data_config.get('resolution', 224),
             expt_ids=self.data_config['expt_ids'],
             input_size=self.data_config.get('input_size', 1536),
@@ -104,6 +102,11 @@ class VideoDataModule(pl.LightningDataModule):
         Args:
             stage: training stage ('fit', 'validate', 'test', or None)
         """
+
+        if stage in ['test', 'predict']:
+            # no test data support as requested
+            return
+            
         if stage in [None, 'fit', 'validate']:
             if self.dataset_train is None or self.dataset_val is None:
                 total_size = len(self.dataset)

--- a/lightning_action/data/video_dataset.py
+++ b/lightning_action/data/video_dataset.py
@@ -1,0 +1,222 @@
+"""Dataset for video action segmentation.
+
+This module contains the VideoDataset class for loading video chunks and labels.
+"""
+
+import os
+import tempfile
+import torch
+import numpy as np
+from torch.utils.data import Dataset
+from nvidia.dali.pipeline import Pipeline
+from nvidia.dali import fn, types
+from typeguard import typechecked
+from tqdm import tqdm
+import logging
+
+logger = logging.getLogger(__name__)
+
+class VideoDataset(Dataset):
+    """Dataset for loading video chunks and corresponding labels.
+    
+    Loads MP4 videos in chunks using DALI for efficient GPU processing.
+    """
+
+    @typechecked
+    def __init__(
+        self,
+        videos_dir: str,
+        labels_dir: str,
+        chunk_size: int = 128,
+        overlap: int = 0,
+        resolution: int = 224,
+        max_frames: int = 72000,
+        expt_ids: list[str] | None = None,
+        input_size: int = 1536,
+        num_lags: int = 0,
+        ignore_index: int = -100,
+    ):
+        """Initialize VideoDataset.
+        
+        Args:
+            videos_dir: directory containing MP4 video files
+            labels_dir: directory containing NumPy (.npy) label files
+            chunk_size: number of frames per chunk for predictions
+            overlap: frame overlap between chunks
+            resolution: output frame resolution
+            max_frames: maximum frames per video
+            expt_ids: list of experiment IDs to filter videos (optional)
+            input_size: dimensionality of input features after processing
+            num_lags: number of context frames on each side
+            ignore_index: value for ignored labels
+            
+        Raises:
+            FileNotFoundError: if missing .npy files
+            ValueError: if invalid video/label lengths or class mismatch
+        """
+        self.videos = [f for f in os.listdir(videos_dir) if f.endswith('.mp4')]
+        if expt_ids:
+            self.videos = [v for v in self.videos if any(v.startswith(eid) for eid in expt_ids)]
+        self.videos_dir = videos_dir
+        self.labels_dir = labels_dir
+        self.chunk_size = chunk_size
+        self.overlap = overlap
+        self.resolution = resolution
+        self.max_frames = max_frames
+        self.input_size = input_size
+        self.num_lags = num_lags
+        self.ignore_index = ignore_index
+        
+        # compute chunks per video and determine num_classes
+        self.video_chunks = []
+        self.label_names = []
+        self.num_classes = 0
+        missing_npy = []
+        for video in tqdm(self.videos, desc="Initializing Video Chunks"):
+            label_path = os.path.join(self.labels_dir, video.replace('.mp4', '.npy'))
+            if not os.path.exists(label_path):
+                missing_npy.append(video)
+            else:
+                labels = np.load(label_path)
+                if labels.ndim > 1 and labels.shape[1] > 1:
+                    if not self.label_names:
+                        self.label_names = [f'class_{i}' for i in range(labels.shape[1])]
+                        self.num_classes = labels.shape[1]
+                    labels = np.argmax(labels, axis=1)
+                else:
+                    unique_labels = np.unique(labels[labels >= 0])
+                    if not self.label_names:
+                        self.num_classes = int(max(unique_labels) + 1) if unique_labels.size > 0 else 1
+                        self.label_names = [f'class_{i}' for i in range(self.num_classes)]
+                total_frames = min(len(labels), max_frames)
+                stride = chunk_size - overlap
+                num_chunks = max(1, (total_frames - chunk_size) // stride + 1)
+                if total_frames > chunk_size:
+                    last_start = num_chunks * stride
+                    if last_start < total_frames:
+                        num_chunks += 1  # Add final chunk to cover remaining frames
+                self.video_chunks.extend([(video, i) for i in range(num_chunks)])
+        if missing_npy:
+            raise FileNotFoundError(f"Missing .npy files for {len(missing_npy)} videos: {missing_npy[:5]}...")
+        logger.info(f"Found {len(self.videos)} videos, {len(self.video_chunks)} chunks, {self.num_classes} classes")
+
+    def __len__(self) -> int:
+        """Return the total number of chunks across all videos."""
+        return len(self.video_chunks)
+
+    @typechecked
+    def __getitem__(self, idx: int) -> tuple[torch.Tensor, torch.Tensor]:
+        """Get a single video chunk and its labels.
+        
+        Args:
+            idx: chunk index
+            
+        Returns:
+            tuple of (frames, labels)
+            
+        Raises:
+            IndexError: if idx is out of range
+            ValueError: if frame size is invalid
+        """
+        if idx >= len(self.video_chunks):
+            raise IndexError(f'Index {idx} out of range for dataset of size {len(self.video_chunks)}')
+        
+        video, chunk_idx = self.video_chunks[idx]
+        video_path = os.path.join(self.videos_dir, video)
+        label_path = os.path.join(self.labels_dir, video.replace('.mp4', '.npy'))
+        
+        # load labels
+        labels = np.load(label_path)
+        if labels.ndim > 1:
+            labels = np.argmax(labels, axis=1)
+        total_frames = min(len(labels), self.max_frames)
+        
+        # compute middle chunk window
+        stride = self.chunk_size - self.overlap
+        start_middle = chunk_idx * stride
+        end_middle = min(start_middle + self.chunk_size, total_frames)
+        if end_middle - start_middle < self.chunk_size:
+            start_middle = max(0, end_middle - self.chunk_size)
+        
+        # compute extended window for context
+        start_frame = max(0, start_middle - self.num_lags)
+        end_frame = min(total_frames, end_middle + self.num_lags)
+        
+        # create temporary file_list for DALI to specify start_frame
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp:
+            tmp.write(f"{video_path} {start_frame}\n")
+            tmp_file = tmp.name
+        
+        loaded_length = end_frame - start_frame
+        
+        # DALI pipeline for GPU video loading
+        pipe = Pipeline(batch_size=1, num_threads=2, device_id=0)
+        with pipe:
+            frames = fn.readers.video(
+                device="gpu",
+                filenames=[video_path],
+                sequence_length=loaded_length,
+                skip_vfr_check=True,
+                file_list_frame_num=True,
+                file_list_include_preceding_frame=False,
+                stride=1,
+                step=-1,
+                random_shuffle=False,
+                pad_last_batch=False,
+                image_type=types.RGB,
+                dtype=types.UINT8,
+            )
+            frames = fn.resize(
+                frames,
+                resize_x=self.resolution,
+                resize_y=self.resolution,
+                interp_type=types.INTERP_LINEAR,
+            )
+            frames = fn.crop_mirror_normalize(
+                frames,
+                dtype=types.FLOAT,
+                output_layout="FCHW",
+                mean=[123.675, 116.28, 103.53],
+                std=[58.395, 57.12, 57.375],
+            )
+            pipe.set_outputs(frames)
+        pipe.build()
+        frames_gpu = pipe.run()[0]
+        frames = torch.from_numpy(frames_gpu.as_cpu().as_array()[0])
+        
+        # clean up temp file
+        os.unlink(tmp_file)
+        
+        # reshape to [loaded_length, 3, resolution, resolution]
+        frames = frames.view(loaded_length, 3, self.resolution, self.resolution)
+        
+        # compute padding amounts
+        extended_size = self.chunk_size + 2 * self.num_lags
+        loaded_pre = start_middle - start_frame
+        loaded_post = end_frame - end_middle
+        left_pad = self.num_lags - loaded_pre
+        right_pad = self.num_lags - loaded_post
+        
+        # pad frames with replicate
+        if left_pad > 0 or right_pad > 0:
+            frames = torch.nn.functional.pad(frames, (0, 0, 0, 0, 0, 0, left_pad, right_pad), mode='replicate')
+        
+        # validate frame shape
+        if frames.shape[0] != extended_size:
+            raise ValueError(f"Extended frame size mismatch: got {frames.shape[0]}, expected {extended_size}")
+        if frames.shape[1:] != (3, self.resolution, self.resolution):
+            raise ValueError(f"Frame size mismatch: got {frames.shape[1:]}")
+        
+        # extract and pad labels for middle only
+        middle_labels = labels[start_middle:end_middle]
+        chunk_labels = torch.from_numpy(middle_labels).long()
+        middle_len = len(chunk_labels)
+        if middle_len < self.chunk_size:
+            pad = (0, self.chunk_size - middle_len)
+            chunk_labels = torch.nn.functional.pad(chunk_labels, pad, value=self.ignore_index)
+        
+        return frames, chunk_labels
+
+    def get_label_names(self) -> list[str]:
+        """Get list of label/class names."""
+        return self.label_names.copy()

--- a/lightning_action/data/video_dataset.py
+++ b/lightning_action/data/video_dataset.py
@@ -28,9 +28,7 @@ class VideoDataset(Dataset):
         videos_dir: str,
         labels_dir: str,
         chunk_size: int = 128,
-        overlap: int = 0,
         resolution: int = 224,
-        max_frames: int = 72000,
         expt_ids: list[str] | None = None,
         input_size: int = 1536,
         num_lags: int = 0,
@@ -42,9 +40,7 @@ class VideoDataset(Dataset):
             videos_dir: directory containing MP4 video files
             labels_dir: directory containing NumPy (.npy) label files
             chunk_size: number of frames per chunk for predictions
-            overlap: frame overlap between chunks
             resolution: output frame resolution
-            max_frames: maximum frames per video
             expt_ids: list of experiment IDs to filter videos (optional)
             input_size: dimensionality of input features after processing
             num_lags: number of context frames on each side
@@ -60,9 +56,7 @@ class VideoDataset(Dataset):
         self.videos_dir = videos_dir
         self.labels_dir = labels_dir
         self.chunk_size = chunk_size
-        self.overlap = overlap
         self.resolution = resolution
-        self.max_frames = max_frames
         self.input_size = input_size
         self.num_lags = num_lags
         self.ignore_index = ignore_index
@@ -88,13 +82,8 @@ class VideoDataset(Dataset):
                     if not self.label_names:
                         self.num_classes = int(max(unique_labels) + 1) if unique_labels.size > 0 else 1
                         self.label_names = [f'class_{i}' for i in range(self.num_classes)]
-                total_frames = min(len(labels), max_frames)
-                stride = chunk_size - overlap
-                num_chunks = max(1, (total_frames - chunk_size) // stride + 1)
-                if total_frames > chunk_size:
-                    last_start = num_chunks * stride
-                    if last_start < total_frames:
-                        num_chunks += 1  # Add final chunk to cover remaining frames
+                total_frames = len(labels)
+                num_chunks = (total_frames + self.chunk_size - 1) // self.chunk_size
                 self.video_chunks.extend([(video, i) for i in range(num_chunks)])
         if missing_npy:
             raise FileNotFoundError(f"Missing .npy files for {len(missing_npy)} videos: {missing_npy[:5]}...")
@@ -129,14 +118,12 @@ class VideoDataset(Dataset):
         labels = np.load(label_path)
         if labels.ndim > 1:
             labels = np.argmax(labels, axis=1)
-        total_frames = min(len(labels), self.max_frames)
+        total_frames = len(labels)
         
         # compute middle chunk window
-        stride = self.chunk_size - self.overlap
-        start_middle = chunk_idx * stride
+        start_middle = chunk_idx * self.chunk_size
         end_middle = min(start_middle + self.chunk_size, total_frames)
-        if end_middle - start_middle < self.chunk_size:
-            start_middle = max(0, end_middle - self.chunk_size)
+        middle_len = end_middle - start_middle
         
         # compute extended window for context
         start_frame = max(0, start_middle - self.num_lags)
@@ -197,9 +184,21 @@ class VideoDataset(Dataset):
         left_pad = self.num_lags - loaded_pre
         right_pad = self.num_lags - loaded_post
         
-        # pad frames with replicate
+        # pad frames with replicate manually
         if left_pad > 0 or right_pad > 0:
-            frames = torch.nn.functional.pad(frames, (0, 0, 0, 0, 0, 0, left_pad, right_pad), mode='replicate')
+            if left_pad > 0:
+                left_padding = frames[0:1].repeat(left_pad, 1, 1, 1)
+                frames = torch.cat([left_padding, frames], dim=0)
+            if right_pad > 0:
+                right_padding = frames[-1:].repeat(right_pad, 1, 1, 1)
+                frames = torch.cat([frames, right_padding], dim=0)
+        
+        # add extra padding if middle_len < chunk_size
+        current_len = frames.shape[0]
+        if current_len < extended_size:
+            extra_right_pad = extended_size - current_len
+            extra_padding = frames[-1:].repeat(extra_right_pad, 1, 1, 1)
+            frames = torch.cat([frames, extra_padding], dim=0)
         
         # validate frame shape
         if frames.shape[0] != extended_size:

--- a/lightning_action/models/video_segmenter.py
+++ b/lightning_action/models/video_segmenter.py
@@ -1,0 +1,484 @@
+"""Video segmentation models with Lightning integration.
+
+This module contains the video segmentation model that processes 
+chunks of video frames through a pretrained ViT-MAE backbone 
+(optionally frozen), pools patch embeddings, appends differencing 
+for temporal features, passes through a flexible temporal backbone 
+(e.g., DTCN, RNN, or TemporalMLP), and classifies per-frame behaviors. 
+"""
+
+import logging
+from abc import abstractmethod
+from typing import Any, List, Tuple, Union
+
+import lightning as pl
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import os
+from jaxtyping import Float, Int
+from torchmetrics import Accuracy, F1Score
+from typeguard import typechecked
+from transformers import ViTMAEModel
+from lightning.pytorch.utilities import rank_zero_only
+
+from lightning_action.models.backbones import DilatedTCN, TemporalMLP, RNN
+
+logger = logging.getLogger(__name__)
+
+class MultiHeadAttentionPooling(nn.Module):
+    """Multi-head attention pooling layer for aggregating patch embeddings."""
+
+    @typechecked
+    def __init__(self, embed_dim: int, num_heads: int):
+        super().__init__()
+        # Initialize query parameter
+        self.query = nn.Parameter(torch.randn(1, 1, embed_dim))
+        # Initialize multihead attention
+        self.attn = nn.MultiheadAttention(embed_dim, num_heads, batch_first=True)
+
+    @typechecked
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # Repeat query for batch size
+        query = self.query.repeat(x.size(0), 1, 1)
+        out, _ = self.attn(query, x, x)
+        return out.squeeze(1)
+
+class VideoBaseModel(pl.LightningModule):
+    """Base Lightning model for video action segmentation.
+    
+    Uses integer labels for efficiency.
+    """
+
+    @typechecked
+    def __init__(self, config: dict[str, Any]):
+        """Initialize base model.
+        
+        Args:
+            config: configuration dictionary with model, optimizer, and training settings
+        """
+        super().__init__()
+        self.save_hyperparameters(config)
+        self.config = config
+        
+        # extract model configuration
+        self.model_config = config.get('model', {})
+        self.input_size = self.model_config['input_size']
+        self.output_size = self.model_config['output_size']
+        self.sequence_length = self.model_config.get('sequence_length', 128)
+
+        # ignore index
+        self.ignore_index = config.get('data', {}).get('ignore_index', -100)
+
+        # set random seed for reproducibility
+        if 'seed' in self.model_config:
+            pl.seed_everything(self.model_config['seed'])
+
+        # initialize metrics
+        self._setup_metrics()
+        
+        # build model architecture (implemented by subclasses)
+        self._build_model()
+
+    def _setup_metrics(self):
+        """Set up torchmetrics for evaluation."""
+        num_classes = self.output_size
+
+        # training metrics
+        self.train_accuracy = Accuracy(
+            task='multiclass', num_classes=num_classes, ignore_index=self.ignore_index,
+        )
+        self.train_f1 = F1Score(
+            task='multiclass', num_classes=num_classes, ignore_index=self.ignore_index,
+        )
+
+        # validation metrics
+        self.val_accuracy = Accuracy(
+            task='multiclass', num_classes=num_classes, ignore_index=self.ignore_index,
+        )
+        self.val_f1 = F1Score(
+            task='multiclass', num_classes=num_classes, ignore_index=self.ignore_index,
+        )
+
+    @abstractmethod
+    def _build_model(self):
+        """Build the model architecture. Implemented by subclasses."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def forward(
+        self,
+        x: Float[torch.Tensor, 'batch sequence features'],
+    ) -> dict[str, torch.Tensor]:
+        """Forward pass through the model.
+        
+        Args:
+            x: input tensor with shape (batch, sequence, features)
+            
+        Returns:
+            dictionary with model outputs including 'logits' and 'probabilities'
+        """
+        raise NotImplementedError
+
+    def compute_loss(
+        self,
+        outputs: dict[str, torch.Tensor],
+        targets: Int[torch.Tensor, 'batch sequence'],
+        stage: str = 'train',
+    ) -> tuple[torch.Tensor, dict[str, float]]:
+        """Compute loss and metrics.
+        
+        Args:
+            outputs: model outputs dictionary
+            targets: ground truth labels (integer class indices)
+            stage: training stage ('train', 'val', 'test')
+            
+        Returns:
+            tuple of (loss tensor, metrics dictionary)
+        """
+        logits = outputs['logits']
+        if hasattr(self, 'num_lags') and self.num_lags > 0:
+            logits = logits[:, self.num_lags:-self.num_lags, :]
+            probabilities = F.softmax(logits, dim=-1)
+        else:
+            probabilities = outputs['probabilities']
+
+        # flatten for loss computation
+        logits_flat = logits.view(-1, self.output_size)
+        targets_flat = targets.view(-1) 
+
+        # Get class weights from config and move to the correct device
+        class_weights = self.model_config.get('class_weights', None)
+        if class_weights is not None:
+            class_weights = torch.tensor(class_weights, device=self.device, dtype=torch.float)
+            
+        # compute cross entropy loss
+        loss = F.cross_entropy(
+            logits_flat,
+            targets_flat,
+            ignore_index=self.ignore_index,
+            weight=class_weights,
+        )
+
+        # compute metrics
+        with torch.no_grad():
+            probs_flat = probabilities.view(-1, self.output_size)
+            pred_classes = torch.argmax(probs_flat.clone(), axis=-1)
+
+            if stage == 'train':
+                accuracy = self.train_accuracy(pred_classes, targets_flat)
+                f1 = self.train_f1(pred_classes, targets_flat)
+            else:  # val or test
+                accuracy = self.val_accuracy(pred_classes, targets_flat)
+                f1 = self.val_f1(pred_classes, targets_flat)
+
+        # handle NaN losses
+        loss_value = loss.item()
+        accuracy_value = accuracy.item()
+        f1_value = f1.item()
+        
+        metrics = {}
+        if not torch.isnan(loss):
+            metrics[f'{stage}_loss'] = loss_value
+        if not torch.isnan(accuracy):
+            metrics[f'{stage}_accuracy'] = accuracy_value
+        if not torch.isnan(f1):
+            metrics[f'{stage}_f1'] = f1_value
+        
+        return loss, metrics
+
+    @typechecked
+    def training_step(
+        self,
+        batch: Union[Tuple[torch.Tensor, torch.Tensor], List[torch.Tensor]],
+        batch_idx: int
+    ) -> torch.Tensor:
+        """Training step for the model.
+        
+        Args:
+            batch: tuple or list of (frames, labels)
+            batch_idx: index of the batch
+            
+        Returns:
+            loss tensor
+        """
+        frames, labels = batch
+        outputs = self.forward(frames)
+        loss, metrics = self.compute_loss(outputs, labels, stage='train')
+        
+        # log metrics
+        self.log('train_loss', loss, prog_bar=True)
+        self.log('train_accuracy', metrics['train_accuracy'], prog_bar=True)
+        self.log('train_f1', metrics['train_f1'], prog_bar=True)
+        
+        return loss
+
+    @typechecked
+    def validation_step(
+        self,
+        batch: Union[Tuple[torch.Tensor, torch.Tensor], List[torch.Tensor]],
+        batch_idx: int
+    ) -> None:
+        """Validation step for the model.
+        
+        Args:
+            batch: tuple or list of (frames, labels)
+            batch_idx: index of the batch
+        """
+        frames, labels = batch
+        outputs = self.forward(frames)
+        loss, metrics = self.compute_loss(outputs, labels, stage='val')
+        
+        # log metrics
+        self.log('val_loss', loss, prog_bar=True)
+        self.log('val_accuracy', metrics['val_accuracy'], prog_bar=True)
+        self.log('val_f1', metrics['val_f1'], prog_bar=True)
+
+    @typechecked
+    def predict_step(
+        self,
+        batch: Union[Tuple[torch.Tensor, torch.Tensor], List[torch.Tensor]],
+        batch_idx: int,
+        dataloader_idx: int | None = None
+    ) -> dict[str, torch.Tensor]:
+        """Prediction step for the model.
+        
+        Args:
+            batch: tuple or list of (frames, labels)
+            batch_idx: index of the batch
+            dataloader_idx: index of the dataloader (optional)
+            
+        Returns:
+            dictionary with predictions
+        """
+        frames, _ = batch  # ignore labels for prediction
+        outputs = self.forward(frames)
+        if hasattr(self, 'num_lags') and self.num_lags > 0:
+            sl = slice(self.num_lags, -self.num_lags)
+            return {
+                'logits': outputs['logits'][:, sl, :],
+                'probabilities': outputs['probabilities'][:, sl, :],
+                'predictions': torch.argmax(outputs['probabilities'][:, sl, :], dim=-1),
+            }
+        else:
+            return {
+                'logits': outputs['logits'],
+                'probabilities': outputs['probabilities'],
+                'predictions': torch.argmax(outputs['probabilities'], dim=-1),
+            }
+
+    def configure_optimizers(self) -> dict[str, Any]:
+        """Configure optimizers and learning rate schedulers.
+        
+        Returns:
+            optimizer configuration dictionary
+        """
+        optimizer_config = self.config.get('optimizer', {})
+        
+        # default optimizer settings
+        optimizer_type = optimizer_config.get('type', 'Adam')
+        lr = optimizer_config.get('lr', 1e-3)
+        weight_decay = optimizer_config.get('wd', 0.0)
+        
+        # create optimizer
+        if optimizer_type.lower() == 'adam':
+            optimizer = torch.optim.Adam(
+                self.parameters(),
+                lr=float(lr),
+                weight_decay=float(weight_decay),
+            )
+        elif optimizer_type.lower() == 'adamw':
+            optimizer = torch.optim.AdamW(
+                self.parameters(),
+                lr=float(lr),
+                weight_decay=float(weight_decay),
+            )
+        else:
+            raise ValueError(f'Unsupported optimizer type: {optimizer_type}')
+        
+        # setup scheduler if specified
+        scheduler_type = optimizer_config.get('scheduler', None)
+        if scheduler_type is None:
+            return optimizer
+        
+        if scheduler_type.lower() == 'step':
+            scheduler = torch.optim.lr_scheduler.StepLR(
+                optimizer,
+                step_size=optimizer_config.get('step_size', 30),
+                gamma=optimizer_config.get('gamma', 0.1),
+            )
+        elif scheduler_type.lower() == 'cosine':
+            scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
+                optimizer,
+                T_max=optimizer_config.get('T_max', 100),
+            )
+        else:
+            raise ValueError(f'Unsupported scheduler type: {scheduler_type}')
+        
+        return {
+            'optimizer': optimizer,
+            'lr_scheduler': {
+                'scheduler': scheduler,
+                'monitor': 'val_loss',
+                'frequency': 1,
+            },
+        }
+
+
+class VideoSegmenter(VideoBaseModel):
+    """Video segmentation model for action recognition.
+    
+    Processes video chunks through ViT-MAE, pooling, differencing, and a flexible backbone.
+    """
+
+    @typechecked
+    def __init__(self, config: dict[str, Any]):
+        """Initialize VideoSegmenter.
+        
+        Args:
+            config: configuration dictionary with model, optimizer, and training settings
+        """
+        self.embed_dim = 768  # ViT-MAE base embedding dim
+        self.num_heads = config.get('model', {}).get('num_heads', 12)  # Default to match ViT
+        self.num_lags = config.get('model', {}).get('num_lags', 0)
+        super().__init__(config)
+        
+        # load ViT-MAE backbone
+        self.beast = ViTMAEModel.from_pretrained('facebook/vit-mae-base')
+        beast_ckpt = self.model_config.get('beast_checkpoint')
+        if beast_ckpt and os.path.exists(beast_ckpt):
+            checkpoint = torch.load(beast_ckpt, map_location='cpu')
+            state_dict = checkpoint.get('state_dict', checkpoint)
+            for prefix in ['beast.', 'vit_mae.vit.']:
+                beast_state_dict = {k.replace(prefix, ''): v for k, v in state_dict.items() if k.startswith(prefix)}
+                if beast_state_dict:
+                    break
+            else:
+                beast_state_dict = state_dict
+            self.beast.load_state_dict(beast_state_dict, strict=False)
+            logger.info(f"Loaded BEAST checkpoint: {beast_ckpt}")
+        
+        self.freeze_beast = self.model_config.get('freeze_beast', True)
+        for param in self.beast.parameters():
+            param.requires_grad = not self.freeze_beast
+        
+        # log model initialization
+        logger.info(f"VideoSegmenter initialized, freeze_beast={self.freeze_beast}")
+        
+        # initialize pooling
+        self.pooling = MultiHeadAttentionPooling(embed_dim=self.embed_dim, num_heads=self.num_heads)
+        
+        # build backbone and classifier
+        self._build_model()
+
+    def _build_model(self):
+        """Build the segmentation model architecture."""
+        self.backbone = self._build_backbone()
+        backbone_output_size = self._get_backbone_output_size()
+        self.classifier = nn.Linear(backbone_output_size, self.output_size)
+        self._initialize_weights()
+
+    def _build_backbone(self) -> nn.Module:
+        """Build the backbone network.
+        
+        Returns:
+            backbone network module
+        """
+        backbone_type = self.model_config.get('backbone', 'dtcn')
+
+        logger.info(f'Constructing VideoSegmenter model with {backbone_type} backbone')
+        
+        if backbone_type.lower() == 'temporalmlp':
+            return TemporalMLP(
+                input_size=self.input_size,
+                num_hid_units=self.model_config['num_hid_units'],
+                num_layers=self.model_config['num_layers'],
+                num_lags=self.model_config.get('num_lags', 1),
+                activation=self.model_config.get('activation', 'lrelu'),
+                dropout_rate=self.model_config.get('dropout_rate', 0.0),
+                seed=self.model_config.get('seed', 42),
+            )
+        elif backbone_type.lower() == 'rnn':
+            return RNN(
+                input_size=self.input_size,
+                num_hid_units=self.model_config['num_hid_units'],
+                num_layers=self.model_config['num_layers'],
+                rnn_type=self.model_config.get('rnn_type', 'lstm'),
+                bidirectional=self.model_config.get('bidirectional', False),
+                dropout_rate=self.model_config.get('dropout_rate', 0.0),
+                seed=self.model_config.get('seed', 42),
+            )
+        elif backbone_type.lower() in ['dtcn', 'dilatedtcn']:
+            return DilatedTCN(
+                input_size=self.input_size,
+                num_hid_units=self.model_config['num_hid_units'],
+                num_layers=self.model_config['num_layers'],
+                num_lags=self.model_config.get('num_lags', 1),
+                activation=self.model_config.get('activation', 'lrelu'),
+                dropout_rate=self.model_config.get('dropout_rate', 0.1),
+                seed=self.model_config.get('seed', 42),
+            )
+        else:
+            raise ValueError(f'Unsupported backbone type: {backbone_type}')
+
+    def _get_backbone_output_size(self) -> int:
+        """Get the output size of the backbone network.
+        
+        Returns:
+            output feature size of the backbone
+        """
+        return self.model_config['num_hid_units']
+
+    def _initialize_weights(self):
+        """Initialize model weights."""
+        for module in self.modules():
+            if isinstance(module, nn.Linear):
+                nn.init.xavier_uniform_(module.weight)
+                if module.bias is not None:
+                    nn.init.zeros_(module.bias)
+
+    @typechecked
+    def forward(
+        self,
+        x: Float[torch.Tensor, 'batch sequence channels height width'],
+    ) -> dict[str, torch.Tensor]:
+        """Forward pass through the video segmentation model.
+        
+        Args:
+            x: input tensor with shape (batch, sequence, 3, height, width)
+            
+        Returns:
+            dictionary with 'logits', 'probabilities', 'features'
+        """
+        b, s, c, h, w = x.shape
+        x = x.view(b * s, c, h, w)
+        
+        # extract embeddings
+        with torch.no_grad() if self.freeze_beast else torch.enable_grad():
+            embeddings = self.beast(pixel_values=x).last_hidden_state[:, 1:, :]
+        
+        # pool
+        pooled = self.pooling(embeddings).view(b, s, -1)
+        
+        # differencing
+        diffs = pooled[:, 1:] - pooled[:, :-1]
+        zero_diff = torch.zeros(b, 1, pooled.shape[-1], device=pooled.device)
+        diffs = torch.cat([zero_diff, diffs], dim=1)
+        
+        # concatenate features
+        features = torch.cat([pooled, diffs], dim=-1)
+        
+        # backbone
+        backbone_output = self.backbone(features)
+        
+        # classifier
+        logits = self.classifier(backbone_output)
+        
+        # probabilities
+        probabilities = F.softmax(logits, dim=-1)
+        
+        return {
+            'logits': logits,
+            'probabilities': probabilities,
+            'features': features,
+        }

--- a/lightning_action/video_train.py
+++ b/lightning_action/video_train.py
@@ -17,6 +17,7 @@ from lightning.pytorch.utilities import rank_zero_only
 from typeguard import typechecked
 from tqdm import tqdm
 from lightning.pytorch.callbacks import LearningRateMonitor, ModelCheckpoint, EarlyStopping
+from lightning.pytorch.loggers import TensorBoardLogger
 
 from lightning_action import __version__
 from lightning_action.data.video_datamodule import VideoDataModule
@@ -77,28 +78,6 @@ def train_video(
         num_lags = 0 if not model_config.get('bidirectional', False) else model_config.get('num_lags', 1)
     data_config['num_lags'] = num_lags
 
-    # Compute overlap to ensure perfect sequence length coverage
-    sequence_length = training_config.get('sequence_length', 128)
-    videos_dir = Path(data_config['videos_dir'])  # Convert to Path for local use
-    video_files = [f for f in os.listdir(videos_dir) if f.endswith('.mp4')]
-    total_frames_list = []
-    for video in video_files:
-        label_path = os.path.join(data_config['labels_dir'], video.replace('.mp4', '.npy'))
-        if os.path.exists(label_path):
-            labels = np.load(label_path)
-            total_frames = min(len(labels), 72000)  # max_frames from VideoDataset
-            total_frames_list.append(total_frames)
-    avg_total_frames = int(np.mean(total_frames_list)) if total_frames_list else 72000
-
-    # Try overlap = num_lags and num_lags * 2, choose the one that minimizes remainder
-    stride1 = sequence_length - num_lags
-    stride2 = sequence_length - num_lags * 2
-    remainder1 = (avg_total_frames - sequence_length) % stride1 if stride1 > 0 else float('inf')
-    remainder2 = (avg_total_frames - sequence_length) % stride2 if stride2 > 0 else float('inf')
-    overlap = num_lags if remainder1 <= remainder2 else num_lags * 2
-    data_config['overlap'] = overlap
-    logger.info(f"Selected overlap: {overlap} for num_lags: {num_lags}, sequence_length: {sequence_length}")
-
     # create datamodule
     datamodule = VideoDataModule(
         data_config=data_config,
@@ -118,7 +97,7 @@ def train_video(
         logger.info(f"Training dataset size: {len(datamodule.dataset_train)} chunks")
         logger.info(f"Validation dataset size: {len(datamodule.dataset_val)} chunks")
 
-    # compute class weights if enabled
+    # compute class weights
     weight_classes = data_config.get('weight_classes', True)
     if weight_classes:
         logger.info("Computing class weights...")
@@ -145,54 +124,49 @@ def train_video(
         config['data']['label_names'] = label_names
         model.config['data']['label_names'] = label_names
 
-    # update training steps information for schedulers
-    num_epochs = training_config.get('num_epochs', 400)
-    batch_size = training_config.get('batch_size', 1)
-    steps_per_epoch = int(np.ceil(len(datamodule.dataset_train) / batch_size))
-    total_steps = steps_per_epoch * num_epochs
+    # save outputs
+    if rank_zero_only.rank == 0:
+        (output_dir / 'config.yaml').parent.mkdir(exist_ok=True, parents=True)
+        with open(output_dir / 'config.yaml', 'w') as f:
+            yaml.dump(config, f, default_flow_style=False)
 
-    # update model config with step information
-    if hasattr(model, 'config'):
-        if 'optimizer' not in model.config:
-            model.config['optimizer'] = {}
-        model.config['optimizer']['steps_per_epoch'] = steps_per_epoch
-        model.config['optimizer']['total_steps'] = total_steps
+    # ----------------------------------------------------------------------------------
+    # Set up trainer
+    # ----------------------------------------------------------------------------------
 
-    logger.info(f"Training steps: {steps_per_epoch} per epoch, {total_steps} total")
+    logger.info("Setting up trainer...")
 
-    # save configuration in output directory
-    logger.info(f"Creating output directory: {output_dir}")
-    output_dir.mkdir(parents=True, exist_ok=True)
-
-    # log package version
-    config['version'] = __version__
-
-    # save config
-    config_yaml = yaml.dump(config)
-    with open(output_dir / 'config.yaml', 'w') as f:
-        f.write(config_yaml)
-
-    # set up callbacks
-    callbacks = get_callbacks(
-        checkpointing=training_config.get('checkpointing', True),
-        lr_monitor=training_config.get('lr_monitor', True),
-        ckpt_every_n_epochs=training_config.get('ckpt_every_n_epochs'),
-        early_stopping=training_config.get('early_stopping', True),
-        early_stopping_patience=training_config.get('early_stopping_patience', 40),
-    )
+    # trainer configuration
+    trainer_config = {
+        'accelerator': training_config.get('device', 'cpu'),
+        'devices': 1,
+        'max_epochs': training_config.get('num_epochs', 100),
+        'precision': training_config.get('precision', '32-true'),
+        'enable_checkpointing': training_config.get('checkpointing', True),
+        'callbacks': get_callbacks(
+            checkpointing=training_config.get('checkpointing', True),
+            lr_monitor=training_config.get('lr_monitor', True),
+            ckpt_every_n_epochs=training_config.get('ckpt_every_n_epochs', None),
+            early_stopping=training_config.get('early_stopping', False),
+            early_stopping_patience=training_config.get('early_stopping_patience', 10),
+        ),
+        'logger': TensorBoardLogger(
+            save_dir=str(output_dir),
+            name='',
+            version='',
+        ),
+        'enable_progress_bar': training_config.get('enable_progress_bar', True),
+        'num_sanity_val_steps': 0,
+    }
 
     # create trainer
-    trainer = pl.Trainer(
-        accelerator=training_config.get('device', 'gpu'),
-        devices=1,
-        max_epochs=num_epochs,
-        default_root_dir=str(output_dir),
-        callbacks=callbacks,
-        enable_progress_bar=training_config.get('progress_bar', True),
-        enable_model_summary=training_config.get('model_summary', True),
-        precision='16-mixed',
-    )
+    trainer = pl.Trainer(**trainer_config)
 
+    # ----------------------------------------------------------------------------------
+    # Train model
+    # ----------------------------------------------------------------------------------
+
+    num_epochs = training_config.get('num_epochs', 100)
     logger.info(f"Starting training for {num_epochs} epochs...")
 
     # train model
@@ -206,8 +180,9 @@ def reset_seeds(seed: int = 0):
     """Reset random seeds for reproducibility.
     
     Args:
-        seed: seed value
+        seed: seed value to use
     """
+    os.environ['PYTHONHASHSEED'] = str(seed)
     random.seed(seed)
     np.random.seed(seed)
     torch.manual_seed(seed)
@@ -252,14 +227,12 @@ def compute_class_weights(datamodule: pl.LightningDataModule, ignore_index: int 
             label_cache[video] = np.load(label_path)
         
         labels = label_cache[video]
-        total_frames = min(len(labels), datamodule.dataset.max_frames)
+        total_frames = len(labels)
         
         # Compute chunk window (mirroring VideoDataset.__getitem__)
-        stride = datamodule.dataset.chunk_size - datamodule.dataset.overlap
+        stride = datamodule.dataset.chunk_size
         start_frame = chunk_idx * stride
         end_frame = min(start_frame + datamodule.dataset.chunk_size, total_frames)
-        if end_frame - start_frame < datamodule.dataset.chunk_size:
-            start_frame = max(0, end_frame - datamodule.dataset.chunk_size)
         
         # Slice labels
         labels_slice = labels[start_frame:end_frame]

--- a/lightning_action/video_train.py
+++ b/lightning_action/video_train.py
@@ -1,0 +1,343 @@
+"""Training functionality for lightning-action video models.
+
+This module provides training functions for video action segmentation models.
+"""
+
+import logging
+import os
+import random
+from pathlib import Path
+from typing import Any
+
+import lightning as pl
+import numpy as np
+import yaml
+import torch
+from lightning.pytorch.utilities import rank_zero_only
+from typeguard import typechecked
+from tqdm import tqdm
+from lightning.pytorch.callbacks import LearningRateMonitor, ModelCheckpoint, EarlyStopping
+
+from lightning_action import __version__
+from lightning_action.data.video_datamodule import VideoDataModule
+from lightning_action.models.video_segmenter import VideoSegmenter
+
+logger = logging.getLogger(__name__)
+
+@typechecked
+def train_video(
+    config: dict[str, Any],
+    model: VideoSegmenter,
+    output_dir: str | Path,
+) -> pl.LightningModule:
+    """Train a Lightning model for video action segmentation.
+
+    Args:
+        config: configuration dictionary with data, model, and training settings
+        model: VideoSegmenter model to train
+        output_dir: directory to save outputs and checkpoints
+
+    Returns:
+        trained model
+
+    Raises:
+        ValueError: if required configuration keys are missing
+        FileNotFoundError: if data directory doesn't exist
+    """
+    output_dir = Path(output_dir)
+
+    # log basic info
+    if rank_zero_only.rank == 0:
+        logger.info(f'Output directory: {output_dir}')
+        logger.info(f'Model type: {type(model)}')
+
+    # reset seeds for reproducibility
+    seed = config.get('training', {}).get('seed', 0)
+    reset_seeds(seed=seed)
+
+    # log configuration
+    if rank_zero_only.rank == 0:
+        logger.info('Configuration:\n' + yaml.dump(config, default_flow_style=False))
+
+    # validate required config sections
+    if 'data' not in config:
+        raise ValueError("Configuration must contain 'data' section")
+    if 'training' not in config:
+        raise ValueError("Configuration must contain 'training' section")
+
+    data_config = config['data']
+    training_config = config['training']
+    model_config = config.get('model', {})
+
+    # Determine num_lags based on backbone
+    backbone_type = model_config.get('backbone', 'dtcn').lower()
+    if backbone_type in ['dtcn', 'dilatedtcn', 'temporalmlp']:
+        num_lags = model_config.get('num_lags', 1)
+    else:
+        num_lags = 0 if not model_config.get('bidirectional', False) else model_config.get('num_lags', 1)
+    data_config['num_lags'] = num_lags
+
+    # Compute overlap to ensure perfect sequence length coverage
+    sequence_length = training_config.get('sequence_length', 128)
+    videos_dir = Path(data_config['videos_dir'])  # Convert to Path for local use
+    video_files = [f for f in os.listdir(videos_dir) if f.endswith('.mp4')]
+    total_frames_list = []
+    for video in video_files:
+        label_path = os.path.join(data_config['labels_dir'], video.replace('.mp4', '.npy'))
+        if os.path.exists(label_path):
+            labels = np.load(label_path)
+            total_frames = min(len(labels), 72000)  # max_frames from VideoDataset
+            total_frames_list.append(total_frames)
+    avg_total_frames = int(np.mean(total_frames_list)) if total_frames_list else 72000
+
+    # Try overlap = num_lags and num_lags * 2, choose the one that minimizes remainder
+    stride1 = sequence_length - num_lags
+    stride2 = sequence_length - num_lags * 2
+    remainder1 = (avg_total_frames - sequence_length) % stride1 if stride1 > 0 else float('inf')
+    remainder2 = (avg_total_frames - sequence_length) % stride2 if stride2 > 0 else float('inf')
+    overlap = num_lags if remainder1 <= remainder2 else num_lags * 2
+    data_config['overlap'] = overlap
+    logger.info(f"Selected overlap: {overlap} for num_lags: {num_lags}, sequence_length: {sequence_length}")
+
+    # create datamodule
+    datamodule = VideoDataModule(
+        data_config=data_config,
+        sequence_length=training_config.get('sequence_length', 128),
+        batch_size=training_config.get('batch_size', 1),
+        num_workers=training_config.get('num_workers', 0),
+        train_probability=training_config.get('train_probability', 0.95),
+        val_probability=training_config.get('val_probability', 0.05),
+        seed=seed,
+    )
+
+    # setup datamodule to access datasets
+    datamodule.setup('fit')
+
+    # log dataset sizes
+    if rank_zero_only.rank == 0:
+        logger.info(f"Training dataset size: {len(datamodule.dataset_train)} chunks")
+        logger.info(f"Validation dataset size: {len(datamodule.dataset_val)} chunks")
+
+    # compute class weights if enabled
+    weight_classes = data_config.get('weight_classes', True)
+    if weight_classes:
+        logger.info("Computing class weights...")
+        class_weights = compute_class_weights(
+            datamodule,
+            ignore_index=data_config.get('ignore_index', -100),
+        )
+
+        # update model configuration with class weights
+        if hasattr(model, 'config'):
+            if 'model' not in model.config:
+                model.config['model'] = {}
+            model.config['model']['class_weights'] = class_weights
+
+        # also store in main config for saving
+        config['model']['class_weights'] = class_weights
+    else:
+        logger.info("Class weighting disabled")
+        config['model']['class_weights'] = None
+
+    # save label names to config
+    label_names = datamodule.get_label_names()
+    if len(label_names) > 0:
+        config['data']['label_names'] = label_names
+        model.config['data']['label_names'] = label_names
+
+    # update training steps information for schedulers
+    num_epochs = training_config.get('num_epochs', 400)
+    batch_size = training_config.get('batch_size', 1)
+    steps_per_epoch = int(np.ceil(len(datamodule.dataset_train) / batch_size))
+    total_steps = steps_per_epoch * num_epochs
+
+    # update model config with step information
+    if hasattr(model, 'config'):
+        if 'optimizer' not in model.config:
+            model.config['optimizer'] = {}
+        model.config['optimizer']['steps_per_epoch'] = steps_per_epoch
+        model.config['optimizer']['total_steps'] = total_steps
+
+    logger.info(f"Training steps: {steps_per_epoch} per epoch, {total_steps} total")
+
+    # save configuration in output directory
+    logger.info(f"Creating output directory: {output_dir}")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # log package version
+    config['version'] = __version__
+
+    # save config
+    config_yaml = yaml.dump(config)
+    with open(output_dir / 'config.yaml', 'w') as f:
+        f.write(config_yaml)
+
+    # set up callbacks
+    callbacks = get_callbacks(
+        checkpointing=training_config.get('checkpointing', True),
+        lr_monitor=training_config.get('lr_monitor', True),
+        ckpt_every_n_epochs=training_config.get('ckpt_every_n_epochs'),
+        early_stopping=training_config.get('early_stopping', True),
+        early_stopping_patience=training_config.get('early_stopping_patience', 40),
+    )
+
+    # create trainer
+    trainer = pl.Trainer(
+        accelerator=training_config.get('device', 'gpu'),
+        devices=1,
+        max_epochs=num_epochs,
+        default_root_dir=str(output_dir),
+        callbacks=callbacks,
+        enable_progress_bar=training_config.get('progress_bar', True),
+        enable_model_summary=training_config.get('model_summary', True),
+        precision='16-mixed',
+    )
+
+    logger.info(f"Starting training for {num_epochs} epochs...")
+
+    # train model
+    trainer.fit(model, datamodule)
+
+    logger.info("Training completed")
+    return model
+
+@typechecked
+def reset_seeds(seed: int = 0):
+    """Reset random seeds for reproducibility.
+    
+    Args:
+        seed: seed value
+    """
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+    pl.seed_everything(seed)
+
+@typechecked
+def compute_class_weights(datamodule: pl.LightningDataModule, ignore_index: int = -100) -> list[float]:
+    """Compute class weights for imbalanced dataset incrementally to avoid memory issues.
+    
+    Computes weights inversely proportional to class frequency, with the most
+    frequent class having weight 1.0.
+    
+    Args:
+        datamodule: Lightning DataModule with datasets
+        ignore_index: class index to ignore
+        
+    Returns:
+        list of class weights
+    """
+    logger.info("Computing class weights from training data...")
+    
+    # ensure datamodule is set up
+    if datamodule.dataset_train is None:
+        datamodule.setup('fit')
+    
+    counts = np.zeros(datamodule.num_classes)
+    
+    # Cache for loaded labels to avoid reloading .npy files multiple times
+    label_cache = {}
+    
+    # Get train indices
+    train_indices = datamodule.dataset_train.indices
+    
+    # Loop over train chunks to count labels (without loading videos)
+    for idx in tqdm(train_indices, desc="Computing class weights"):
+        video, chunk_idx = datamodule.dataset.video_chunks[idx]
+        label_path = os.path.join(datamodule.dataset.labels_dir, video.replace('.mp4', '.npy'))
+        
+        # Load labels if not cached
+        if video not in label_cache:
+            label_cache[video] = np.load(label_path)
+        
+        labels = label_cache[video]
+        total_frames = min(len(labels), datamodule.dataset.max_frames)
+        
+        # Compute chunk window (mirroring VideoDataset.__getitem__)
+        stride = datamodule.dataset.chunk_size - datamodule.dataset.overlap
+        start_frame = chunk_idx * stride
+        end_frame = min(start_frame + datamodule.dataset.chunk_size, total_frames)
+        if end_frame - start_frame < datamodule.dataset.chunk_size:
+            start_frame = max(0, end_frame - datamodule.dataset.chunk_size)
+        
+        # Slice labels
+        labels_slice = labels[start_frame:end_frame]
+        
+        # Handle one-hot if necessary
+        if labels_slice.ndim > 1 and labels_slice.shape[-1] > 1:
+            labels_slice = np.argmax(labels_slice, axis=-1)
+        
+        # Filter ignore_index
+        labels_slice = labels_slice[labels_slice != ignore_index]
+        
+        # Count unique classes
+        unique, batch_counts = np.unique(labels_slice, return_counts=True)
+        for cls, count in zip(unique, batch_counts):
+            if 0 <= cls < datamodule.num_classes:
+                counts[cls] += count
+    
+    # compute class weights
+    if np.sum(counts) == 0:
+        logger.warning("No labeled examples found, using uniform weights")
+        return [1.0] * datamodule.num_classes
+    
+    max_count = np.max(counts)
+    class_weights = max_count / (counts + 1e-10)
+    class_weights[counts == 0] = 0.0
+    
+    logger.info(f"Class counts: {counts}")
+    logger.info(f"Class weights: {class_weights}")
+    
+    return class_weights.tolist()
+
+@typechecked
+def get_callbacks(
+    checkpointing: bool = True,
+    lr_monitor: bool = True,
+    ckpt_every_n_epochs: int | None = None,
+    early_stopping: bool = False,
+    early_stopping_patience: int = 10,
+) -> list[pl.Callback]:
+    """Get Lightning callbacks for training.
+    
+    Args:
+        checkpointing: enable model checkpointing
+        lr_monitor: monitor learning rate
+        ckpt_every_n_epochs: save checkpoint every N epochs
+        early_stopping: enable early stopping
+        early_stopping_patience: patience for early stopping
+        
+    Returns:
+        list of callbacks
+    """
+    callbacks = []
+    
+    if lr_monitor:
+        callbacks.append(LearningRateMonitor(logging_interval='epoch'))
+    
+    if checkpointing:
+        callbacks.append(ModelCheckpoint(
+            monitor='val_loss',
+            mode='min',
+            filename='{epoch}-{step}-best',
+            save_top_k=1,
+        ))
+    
+    if ckpt_every_n_epochs is not None:
+        callbacks.append(ModelCheckpoint(
+            monitor=None,
+            every_n_epochs=ckpt_every_n_epochs,
+            save_top_k=-1,
+            filename='{epoch}-{step}',
+        ))
+    
+    if early_stopping:
+        callbacks.append(EarlyStopping(
+            monitor='val_loss',
+            mode='min',
+            patience=early_stopping_patience,
+            verbose=True,
+        ))
+    
+    return callbacks


### PR DESCRIPTION
This pipeline expects a folder of mp4 videos along with npy labels for corresponding videos and works as follows:

1. Load small chunks of videos at a time into a backbone in the form of a checkpoint file. We have the option of using a frozen or unfrozen backbone here. If unfrozen the weights update with the rest of the model during training.

2. This backbone transforms each frame into patch embeddings. Since the patch embeddings in total are so large that it leads to memory issues, hence a key difference between this pipeline and the previous is we load in small chunks of data and push it all the way through the pipeline, compute a loss, update the weights, and repeat so we don't load too much into memory at any one time.

3. Patch embeddings are then ran through a multi-head attention layer reducing dimensions to 768.

4. We compute a differenced embedding and append it to that pooled patch embedding to get a combined dimension of 1536.

5. This frame transformed to a 1536 dimension latent and all appropriate surrounding latents depending on 'num_lags' is then fed through a dtcn backbone (can swap for temporalMLP or rnn if desired), the weights of which we will always update through the training process.

6. We attach a classifier that takes the output of the backbone and transforms it to whatever 'output_size'

7. We compute a loss comparing predictions to the appropriate npy labels and update the weights of the dtcn/classifier. We additionally update the backbone from step 2 if unfrozen.

8. Repeat. Typically you load all or most data in first before you start running computations. Since we run into memory issues with the patch embeddings a key point here is we want to only load what we need, then do steps 1-8.