### PR TITLE
fix lightning version to 2.5.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 
 dependencies = [
     "jaxtyping",
-    "lightning",
+    "lightning (~=2.5)",
     "numpy (>=2.0.0)",
     "nvidia-dali-cuda110",
     "opencv-python-headless",


### PR DESCRIPTION
fixing lightning version to 2.5.x in response to supply chain attack detailed [here](https://socket.dev/blog/lightning-pypi-package-compromised)